### PR TITLE
fix(package) update moment to newest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/wraithgar/ambit/issues"
   },
   "dependencies": {
-    "moment": "^2.11.0",
+    "moment": "^2.11.2",
     "moonbeams": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There was a security advisory affecting moment, updating to 2.11.2
The problem was in moment.duration, which this library doesn't use,
but at least by requiring this version we will 'float' any libraries
that require this and moment ^2.0.0 into using the version that's
patched against the regex DOS.

See https://github.com/moment/moment/issues/2936 for info on the security
vulnerability